### PR TITLE
Ensure damaging NCA works as expected

### DIFF
--- a/configs/growing_nca_with_damage.yaml
+++ b/configs/growing_nca_with_damage.yaml
@@ -2,11 +2,11 @@
 
 weights_dir: 'ckpts/damage_ckpt'
 checkpoint_dir: 'ckpts/damage_ckpt'
-pool_size: 1000
+pool_size: 1024 
 target_filename: "emoji_imgs/smile.png"
-damage: False # TODO: No longer works with current train.py 
+n_damage: 3
 learning_rate: 0.003
-total_training_steps: 50000
+total_training_steps: 20000
 batch_size: 8
 num_nca_steps: 48
 log_every: 100

--- a/configs/growing_nca_with_damage.yaml
+++ b/configs/growing_nca_with_damage.yaml
@@ -1,15 +1,15 @@
 # This is for replicating https://distill.pub/2020/growing-ca/
 
-weights_dir: '33'
-#weights_dir: 'damage_ckpt'
+#weights_dir: '33'
+weights_dir: 'damaged_smile/damage_ckpt/'
 checkpoint_dir: 'ckpts/damage_ckpt'
 pool_size: 1024 
 target_filename: "emoji_imgs/smile.png"
-n_damage: 5
-learning_rate: 0.001
-total_training_steps: 40000
-batch_size: 16
-num_nca_steps: 84
+n_damage: 1
+learning_rate: 0.0001
+total_training_steps: 100000
+batch_size: 4
+num_nca_steps: 120
 log_every: 200
 
 

--- a/configs/growing_nca_with_damage.yaml
+++ b/configs/growing_nca_with_damage.yaml
@@ -1,14 +1,15 @@
 # This is for replicating https://distill.pub/2020/growing-ca/
 
-weights_dir: 'ckpts/damage_ckpt'
+weights_dir: '33'
+#weights_dir: 'damage_ckpt'
 checkpoint_dir: 'ckpts/damage_ckpt'
 pool_size: 1024 
 target_filename: "emoji_imgs/smile.png"
-n_damage: 3
-learning_rate: 0.003
-total_training_steps: 20000
-batch_size: 8
-num_nca_steps: 48
-log_every: 100
+n_damage: 5
+learning_rate: 0.001
+total_training_steps: 40000
+batch_size: 16
+num_nca_steps: 84
+log_every: 200
 
 

--- a/nca/config.py
+++ b/nca/config.py
@@ -19,7 +19,7 @@ class NCAConfig:
     log_dir: str = "logs"
     log_every: int = 500
     num_nca_steps: int = 64  # number of steps to run NCA for
-    damage: bool = False  # whether to damage the target during training
+    n_damage: int = 3  # number of states in a batch to damage
 
     # evaluation parameters
     total_eval_steps: int = 300

--- a/nca/dataset.py
+++ b/nca/dataset.py
@@ -92,7 +92,7 @@ class NCADataGenerator:
         return jnp.asarray(target)
 
     @staticmethod
-    def random_cutout_rect(img_nchw, min_size=(4, 4), max_size=(32, 32)):
+    def random_cutout_rect(img_nchw: Array, min_size=(4, 4), max_size=(32, 32)):
         rand_h = tf.random.uniform(
             shape=[], minval=min_size[0], maxval=max_size[0], dtype=tf.int32
         )
@@ -114,15 +114,15 @@ class NCADataGenerator:
         return img_nchw
 
     @staticmethod
-    def random_cutout_circle(img_nchw, key):
+    def random_cutout_circle(img_nchw: Array, seed: int):
         img_nhwc = NCHW_to_NHWC(img_nchw)
 
         n, h, w, _ = img_nhwc.shape
 
         x = tf.linspace(-1.0, 1.0, w)[None, None, :]
         y = tf.linspace(-1.0, 1.0, h)[None, :, None]
-        center = tf.random.uniform([2, n, 1, 1], -0.5, 0.5, seed=key)
-        r = tf.random.uniform([n, 1, 1], 0.1, 0.3, seed=key)
+        center = tf.random.uniform([2, n, 1, 1], -0.5, 0.5, seed=seed)
+        r = tf.random.uniform([n, 1, 1], 0.1, 0.3, seed=seed)
         x, y = (x - center[0]) / r, (y - center[1]) / r
         mask = tf.cast(x * x + y * y < 1.0, tf.float32)
         img_masked = img_nhwc * (1.0 - mask[..., tf.newaxis])

--- a/nca/dataset.py
+++ b/nca/dataset.py
@@ -122,10 +122,10 @@ class NCADataGenerator:
         x = tf.linspace(-1.0, 1.0, w)[None, None, :]
         y = tf.linspace(-1.0, 1.0, h)[None, :, None]
         center = tf.random.uniform([2, n, 1, 1], -0.5, 0.5, seed=seed)
-        r = tf.random.uniform([n, 1, 1], 0.1, 0.3, seed=seed)
+        r = tf.random.uniform([n, 1, 1], 0.1, 0.4, seed=seed)
         x, y = (x - center[0]) / r, (y - center[1]) / r
         mask = tf.cast(x * x + y * y < 1.0, tf.float32)
-        img_masked = img_nhwc * (1.0 - mask[..., tf.newaxis])
+        img_masked = img_nhwc * (1.0 - 0.5 * mask[..., tf.newaxis])
         img_masked = np.asarray(img_masked)
         img_masked_nchw = NHWC_to_NCHW(img_masked)
         return img_masked_nchw

--- a/nca/dataset.py
+++ b/nca/dataset.py
@@ -125,7 +125,7 @@ class NCADataGenerator:
         r = tf.random.uniform([n, 1, 1], 0.1, 0.4, seed=seed)
         x, y = (x - center[0]) / r, (y - center[1]) / r
         mask = tf.cast(x * x + y * y < 1.0, tf.float32)
-        img_masked = img_nhwc * (1.0 - 0.5 * mask[..., tf.newaxis])
+        img_masked = img_nhwc * (1.0 - mask[..., tf.newaxis])
         img_masked = np.asarray(img_masked)
         img_masked_nchw = NHWC_to_NCHW(img_masked)
         return img_masked_nchw

--- a/nca/trainer.py
+++ b/nca/trainer.py
@@ -404,10 +404,7 @@ def evaluate(config: NCAConfig, output_video_path: Optional[str] = None) -> None
         # state_grid = np.asarray(state_grid).copy()
         # state_grid[:, : ,  : , :state_grid.shape[2]//2] = 0.0
 
-        # 2) make a random rectange cutouts, 2 times
-        state_grid = NCADataGenerator.random_cutout_rect(
-            state_grid, max_size=(16, 16), seed=int(key[0])  # type: ignore
-        )
+        # 2) make a random rectange cutouts
         state_grid = NCADataGenerator.random_cutout_rect(
             state_grid, max_size=(16, 16), seed=int(key[0])  # type: ignore
         )

--- a/nca/trainer.py
+++ b/nca/trainer.py
@@ -398,14 +398,23 @@ def evaluate(config: NCAConfig, output_video_path: Optional[str] = None) -> None
         state_grid = state_grid_array[-1]
         state_grid_cache.append(jnp.squeeze(state_grid_array))
 
-        state_grid = NCADataGenerator.random_cutout_rect(state_grid, max_size=(16, 16))
-        state_grid = NCADataGenerator.random_cutout_rect(state_grid, max_size=(16, 16))
+        state_grid = NCADataGenerator.random_cutout_rect(
+            state_grid, max_size=(16, 16), seed=int(key[0]) # type: ignore
+        )
+        state_grid = NCADataGenerator.random_cutout_rect(
+            state_grid, max_size=(16, 16), seed=int(key[0]) # type: ignore
+        )
+
+        # state_grid = NCADataGenerator.random_cutout_circle(state_grid, key[0])
+
+        key, _ = jax.random.split(key)
 
     state_grid_cache = jnp.array(state_grid_cache)  # type: ignore
 
     state_grid_cache = jnp.concatenate(state_grid_cache, axis=0)
     # save the entire state_grid_cache as npy.
     # TODO: add path to config.
+
     np.save("/tmp/state_grid_cache.npy", state_grid_cache)
 
     state_grid_cache = jnp.clip(state_grid_cache, 0.0, 1.0)

--- a/nca/trainer.py
+++ b/nca/trainer.py
@@ -398,14 +398,19 @@ def evaluate(config: NCAConfig, output_video_path: Optional[str] = None) -> None
         state_grid = state_grid_array[-1]
         state_grid_cache.append(jnp.squeeze(state_grid_array))
 
-        state_grid = NCADataGenerator.random_cutout_rect(
-            state_grid, max_size=(16, 16), seed=int(key[0]) # type: ignore
-        )
-        state_grid = NCADataGenerator.random_cutout_rect(
-            state_grid, max_size=(16, 16), seed=int(key[0]) # type: ignore
-        )
+        ###  Some cutout strategies ###
+        # 1) split the grid into two and make one half black
+        #
+        # state_grid = np.asarray(state_grid).copy()
+        # state_grid[:, : ,  : , :state_grid.shape[2]//2] = 0.0
 
-        # state_grid = NCADataGenerator.random_cutout_circle(state_grid, key[0])
+        # 2) make a random rectange cutouts, 2 times
+        state_grid = NCADataGenerator.random_cutout_rect(
+            state_grid, max_size=(16, 16), seed=int(key[0])  # type: ignore
+        )
+        state_grid = NCADataGenerator.random_cutout_rect(
+            state_grid, max_size=(16, 16), seed=int(key[0])  # type: ignore
+        )
 
         key, _ = jax.random.split(key)
 

--- a/nca/utils.py
+++ b/nca/utils.py
@@ -119,7 +119,9 @@ def make_video(
 
 
 def mse(
-    pred_rgb: jnp.ndarray, target: jnp.ndarray, reduce_mean: bool = True
+    pred_rgb: Union[jnp.ndarray, np.ndarray],
+    target: Union[jnp.ndarray, np.ndarray],
+    reduce_mean: bool = True,
 ) -> jnp.ndarray:
     if reduce_mean == True:
         loss_value = jnp.mean(jnp.square(pred_rgb - target))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,22 +1,21 @@
 import pytest
-
-from context import *
-from nca.dataset import NCADataGenerator
 import jax
 import numpy as np
+from context import *
+from nca.dataset import NCADataGenerator
 from nca.utils import NCHW_to_NHWC, NHWC_to_NCHW
 
 
 @pytest.fixture
-def generator():
+def generator() -> NCADataGenerator:
     return NCADataGenerator(100, 32, (40, 40), 16)
 
 
-def test_init(generator):
+def test_initialization(generator: NCADataGenerator):
     assert generator.pool.shape == (100, 16, 40, 40)
 
 
-def test_sample(generator):
+def test_sample_generation(generator: NCADataGenerator):
     key = jax.random.PRNGKey(0)
 
     pool1, indices1 = generator.sample(key)
@@ -29,23 +28,23 @@ def test_sample(generator):
     assert pool2.shape == (32, 16, 40, 40)
 
 
-def test_update_pool(generator):
+def test_pool_update(generator: NCADataGenerator):
     indices = np.array([0, 1, 2, 3])
     new_states = np.ones((4, 16, 40, 40))
 
     generator.update_pool(indices, new_states)
 
 
-def test_get_target(generator):
+def test_target_retrieval(generator: NCADataGenerator):
     target = generator.get_target("emoji_imgs/skier.png")
     assert target.shape == (32, 4, 40, 40)
 
 
-def test_random_cutout(generator):
-    # random data
+def test_random_cutout_circle(generator: NCADataGenerator):
+    # Generate random data
     data_nhwc = np.zeros((generator.batch_size,) + generator.dimensions + (3,))
     data_nchw = NHWC_to_NCHW(data_nhwc)
 
-    masked_data = generator.random_cutout_circle(data_nchw)
+    masked_data = generator.random_cutout_circle(data_nchw, seed=0)
 
     assert masked_data.shape == data_nchw.shape

--- a/tests/test_nca.py
+++ b/tests/test_nca.py
@@ -1,14 +1,14 @@
 import pytest
 import numpy as np
 from jax import random
-import cv2  # type: ignore
+import cv2
 
 from context import *
 from nca.nca import *
 from nca.model import UpdateModel
 
 
-def test_create_perception_kernel():
+def test_perception_kernel_creation():
     kernel_x, kernel_y = create_perception_kernel(
         input_size=64, output_size=8, use_oihw_layout=True
     )
@@ -22,7 +22,7 @@ def test_create_perception_kernel():
     assert kernel_y.shape == (1, 1, 3, 3)
 
 
-def test_perceive():
+def test_perception_function():
     # Set up random input data
     key = random.PRNGKey(0)
     input_shape = (1, 16, 32, 32)
@@ -36,15 +36,15 @@ def test_perceive():
     assert y.shape == (1, 16 * 3, 32, 32)
 
 
-def test_update():
+def test_cell_update_function():
     # Set up random input data
-    key = jax.random.PRNGKey(0)
+    key = random.PRNGKey(0)
     input_shape = (4, 16, 32, 32)
-    x = jax.random.normal(key, input_shape)
+    x = random.normal(key, input_shape)
 
     # Initialize the model and its parameters
     model = UpdateModel()
-    rand_data = jax.random.normal(key, (1, 32, 32, 16 * 3))
+    rand_data = random.normal(key, (1, 32, 32, 16 * 3))
     params = model.init(key, rand_data)
 
     # Create the perception kernel

--- a/tests/test_nca.py
+++ b/tests/test_nca.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 from jax import random
-import cv2
+import cv2  # type: ignore
 
 from context import *
 from nca.nca import *


### PR DESCRIPTION
In this PR, I conducted several experiments to develop a strategy for NCA to regenerate from a damaged state. After several trials, I arrived at the following approach:

* First, I trained NCA without damage for approximately 10k steps, using a batch size of 16.
* Next, I trained the damaged NCA with a reduced batch size of 4, damaging only one sample in each batch, and continuing training for an additional 30k steps.

In addition, removed the damage logic from the dataset generator and placing it into train_and_eval. 


