### PR TITLE
Fix NCA compatibility and CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pytest
 To train the model run the following command
 
 ```bash
-python main.py --config configs/growing_nca.yaml 
+python main.py --config_path configs/growing_nca.yaml
 ``` 
 
 Configuration settings can be defined using YAML files. The default configuration file to reproduce the results mentioned in the paper can be found at `configs/growing_nca_with_damage.yaml`. For all the default configurations, please refer to nca/configs.py.
@@ -96,8 +96,7 @@ To perform inference on a trained model, execute the following command.
 
 
 ```bash
-python main.py --config_path=configs/growing_demo.yaml --mode=evaluate --output_video_path=demo.mp4
-2023
+python main.py --config_path=configs/growing_nca.yaml --mode=evaluate --output_video_path=demo.mp4
 ```
 
 Please ensure that you update the `weights_dir` field in the configuration file with the accurate path to the downloaded checkpoint. Additionally, specify the `output_video_path` to determine the location where the NCA propagation will be saved in video format.

--- a/nca/config.py
+++ b/nca/config.py
@@ -21,6 +21,9 @@ class NCAConfig:
     log_every: int = 500
     num_nca_steps: int = 64  # number of steps to run NCA for
     n_damage: int = 3  # number of states in a batch to damage
+    # Kept for compatibility with older YAML files.  New configurations
+    # should use ``n_damage`` to control damage augmentation.
+    damage: bool = False
 
     # evaluation parameters
     total_eval_steps: int = 300

--- a/nca/dataset.py
+++ b/nca/dataset.py
@@ -5,7 +5,6 @@ import jax
 import jax.numpy as jnp
 import cv2  # type: ignore
 import tensorflow as tf  # type: ignore
-import keras_cv
 
 from nca.utils import NCHW_to_NHWC, NHWC_to_NCHW
 
@@ -86,28 +85,29 @@ class NCADataGenerator:
         width_factor: float = 0.1,
         seed: int = 10,
     ):
-        img_nhwc = NCHW_to_NHWC(img_nchw)
-        img_nhwc = keras_cv.layers.RandomCutout(height_factor, width_factor, seed=seed)(
-            img_nhwc
-        )
-
-        img_nchw = NHWC_to_NCHW(img_nhwc)
-
-        return img_nchw
+        # Keep augmentation in NumPy.  The previous KerasCV implementation
+        # unconditionally used TensorFlow device kernels, which fails on
+        # machines whose installed CUDA PTX does not match the GPU.
+        img = np.asarray(NCHW_to_NHWC(img_nchw)).copy()
+        rng = np.random.default_rng(seed)
+        n, h, w, _ = img.shape
+        cutout_h = max(1, int(round(h * height_factor)))
+        cutout_w = max(1, int(round(w * width_factor)))
+        for i in range(n):
+            y = rng.integers(0, max(1, h - cutout_h + 1))
+            x = rng.integers(0, max(1, w - cutout_w + 1))
+            img[i, y : y + cutout_h, x : x + cutout_w, :] = 0
+        return NHWC_to_NCHW(img)
 
     @staticmethod
     def random_cutout_circle(img_nchw: Array, seed: int):
-        img_nhwc = NCHW_to_NHWC(img_nchw)
-
-        n, h, w, _ = img_nhwc.shape
-
-        x = tf.linspace(-1.0, 1.0, w)[None, None, :]
-        y = tf.linspace(-1.0, 1.0, h)[None, :, None]
-        center = tf.random.uniform([2, n, 1, 1], -0.5, 0.5, seed=seed)
-        r = tf.random.uniform([n, 1, 1], 0.05, 0.2, seed=seed)
-        x, y = (x - center[0]) / r, (y - center[1]) / r
-        mask: tf.Tensor = tf.cast(x * x + y * y < 1.0, tf.float32)
-        img_masked = img_nhwc * (1.0 - mask[..., tf.newaxis])
-        img_masked = np.asarray(img_masked)
-        img_masked_nchw = NHWC_to_NCHW(img_masked)
-        return img_masked_nchw
+        img = np.asarray(NCHW_to_NHWC(img_nchw)).copy()
+        n, h, w, _ = img.shape
+        rng = np.random.default_rng(seed)
+        yy, xx = np.mgrid[-1 : 1 : complex(0, h), -1 : 1 : complex(0, w)]
+        for i in range(n):
+            cx, cy = rng.uniform(-0.5, 0.5, size=2)
+            radius = rng.uniform(0.05, 0.2)
+            mask = ((xx - cx) / radius) ** 2 + ((yy - cy) / radius) ** 2 < 1.0
+            img[i][mask] = 0
+        return NHWC_to_NCHW(img)

--- a/nca/trainer.py
+++ b/nca/trainer.py
@@ -46,6 +46,7 @@ def create_state(config: NCAConfig) -> Tuple[train_state.TrainState, Any]:
         (1, config.dimensions[0], config.dimensions[1], config.model_output_len * 3),
     )
 
+    restored_dict = None
     if config.weights_dir:
         restored_dict = checkpoints.restore_checkpoint(config.weights_dir, target=None)
 
@@ -167,7 +168,7 @@ def train_step(
     (loss, state_grid_sequence), grad = grad_fn(state.params, state_grid, key)
 
     if apply_grad:
-        grad = jax.tree_map(
+        grad = jax.tree_util.tree_map(
             lambda g: jnp.nan_to_num(g / (jnp.linalg.norm(g) + 1e-8)), grad
         )
         state = state.apply_gradients(grads=grad)

--- a/nca/utils.py
+++ b/nca/utils.py
@@ -2,7 +2,13 @@ import jax
 import jax.numpy as jnp
 import tensorflow as tf
 import numpy as np
-from moviepy.editor import ImageSequenceClip  # type: ignore
+
+try:
+    # MoviePy 1.x exposed this from ``moviepy.editor``; MoviePy 2.x exports
+    # it from the package root.
+    from moviepy import ImageSequenceClip  # type: ignore
+except ImportError:  # pragma: no cover - exercised with MoviePy 1.x
+    from moviepy.editor import ImageSequenceClip  # type: ignore
 import tempfile
 from glob import glob
 import cv2  # type: ignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flax
 optax
+jax[cpu]
 black
 moviepy
 tensorboardX


### PR DESCRIPTION
## What changed
- add the missing CPU JAX dependency
- support current MoviePy and JAX APIs
- make cutout augmentation independent of incompatible TensorFlow CUDA kernels
- fix legacy config loading and README commands

## Validation
- `python -m pytest -q` — 16 passed
- `python -m py_compile main.py nca/*.py`
- `black --check .`
- `git diff --check`