### PR TITLE
Benchmark faster and second-derivative NCA perception

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,6 @@ jobs:
         run: |
           sudo apt install libgl1
           python -m pip install --upgrade pip
-          pip install jax
           pip install -r requirements.txt
       - name: Run tests with pytest
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM nvcr.io/nvidia/tensorflow:22.09-tf2-py3
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt install python3-pip libgl1 libglib2.0-dev -y
-
-RUN pip install "jax[cuda11_cudnn86]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+RUN apt update && apt install python3-pip libgl1 libglib2.0-dev ffmpeg -y
 
 # Copy application files
 WORKDIR /nca
@@ -13,8 +11,7 @@ COPY . .
 # Install Python dependencies
 RUN pip install --upgrade pip
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements-gpu.txt
 
 # Set the entrypoint
 #ENTRYPOINT ["python3", "main.py"]
-

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ setup:
 	pip install -r $(REQUIREMENTS_FILE)
 	@echo "Done ✌️"
 
+setup-gpu:
+	@echo "Installing GPU dependencies..."
+	pip install -r requirements-gpu.txt
+	@echo "Done ✌️"
+
 clean:
 	@read -p "Are you sure you want to delete ckpts and logs? [y/N] " confirmation && \
     	if [ "$$confirmation" = "y" ] || [ "$$confirmation" = "Y" ] ; then \

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ Install the other dependencies with pip
 pip install -r requirements.txt
 ```
 
+For NVIDIA GPU training, use the CUDA 12 JAX extra instead:
+
+```bash
+make setup-gpu
+python -c "import jax; print(jax.devices())"
+python main.py --config_path configs/growing_nca.yaml
+```
+
+The device check should report a `CudaDevice`. The Dockerfile provides the same
+CUDA 12 setup for a containerized run.
+
 
 #### With GPU docker (recommended)
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Configuration settings can be defined using YAML files. The default configuratio
 
 To specify your own target image, you can modify the `target_filename` field in the YAML file to the desired image filename. Please ensure that the image has an alpha channel.
 
+Select the perception implementation with `perception_method`: `sobel` (the original two-convolution path), `sobel_fused` (an equivalent fused convolution), `sobel_second` (adds second derivatives), or `learned` (a trainable 3x3 convolutional perception block). Compare them with:
+
+```bash
+python scripts/benchmark_perception.py --steps 100 --nca-steps 32
+```
+
 
 ### Inference
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pytest
 To train the model run the following command
 
 ```bash
-python main.py --config configs/growing_nca.yaml 
+python main.py --config_path configs/growing_nca.yaml
 ``` 
 
 Configuration settings can be defined using YAML files. The default configuration file to reproduce the results mentioned in the paper can be found at `configs/growing_nca_with_damage.yaml`. For all the default configurations, please refer to nca/configs.py.
@@ -96,8 +96,7 @@ To perform inference on a trained model, execute the following command.
 
 
 ```bash
-python main.py --config_path=configs/growing_demo.yaml --mode=evaluate --output_video_path=demo.mp4
-2023
+python main.py --config_path=configs/growing_nca.yaml --mode=evaluate --output_video_path=demo.mp4
 ```
 
 Please ensure that you update the `weights_dir` field in the configuration file with the accurate path to the downloaded checkpoint. Additionally, specify the `output_video_path` to determine the location where the NCA propagation will be saved in video format.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Configuration settings can be defined using YAML files. The default configuratio
 
 To specify your own target image, you can modify the `target_filename` field in the YAML file to the desired image filename. Please ensure that the image has an alpha channel.
 
-Select the perception implementation with `perception_method`: `sobel` (the original two-convolution path), `sobel_fused` (an equivalent fused convolution), `sobel_second` (adds second derivatives), or `learned` (a trainable 3x3 convolutional perception block). Compare them with:
+Select the perception implementation with `perception_method`: `sobel` (the original two-convolution path), `sobel_fused` (an equivalent fused convolution), `sobel_second` (adds second derivatives), `sobel_multiscale` (combines 3x3 and 5x5 gradients), or `learned` (a trainable 3x3 convolutional perception block). Compare them with:
 
 ```bash
 python scripts/benchmark_perception.py --steps 100 --nca-steps 32

--- a/configs/exp_dodrio_56x56_sobel_second.yaml
+++ b/configs/exp_dodrio_56x56_sobel_second.yaml
@@ -1,0 +1,21 @@
+# Random Pokémon experiment: dodrio.png at 56x56 using second-derivative
+# perception. Outputs are isolated from the existing checkpoint directories.
+dimensions: [56, 56]
+model_output_len: 16
+perception_method: sobel_second
+batch_size: 4
+pool_size: 1000
+total_training_steps: 100000
+num_nca_steps: 64
+total_eval_steps: 300
+learning_rate: 0.0001
+n_damage: 1
+target_filename: "/mnt/ssd1/data/git/NCA/data/pokemon_emoji/emojis/dodrio.png"
+weights_dir: ""
+checkpoint_dir: "runs/dodrio_56x56_sobel_second/checkpoints"
+validation_video_dir: "runs/dodrio_56x56_sobel_second/validation_videos"
+log_dir: "runs/dodrio_56x56_sobel_second/logs"
+evaluation_video_file: "runs/dodrio_56x56_sobel_second/evaluation.mp4"
+checkpoint_every: 500
+eval_every: 500
+log_every: 500

--- a/configs/exp_dodrio_56x56_sobel_second_random20.yaml
+++ b/configs/exp_dodrio_56x56_sobel_second_random20.yaml
@@ -1,0 +1,23 @@
+# Random Pokémon experiment: dodrio.png at 56x56 using second-derivative
+# perception and a fixed random 20% grid-cell seed distribution.
+dimensions: [56, 56]
+model_output_len: 16
+perception_method: sobel_second
+seed_density: 0.2
+seed_random_seed: 0
+batch_size: 4
+pool_size: 1000
+total_training_steps: 100000
+num_nca_steps: 64
+total_eval_steps: 300
+learning_rate: 0.0001
+n_damage: 1
+target_filename: "/mnt/ssd1/data/git/NCA/data/pokemon_emoji/emojis/dodrio.png"
+weights_dir: ""
+checkpoint_dir: "runs/dodrio_56x56_sobel_second_random20/checkpoints"
+validation_video_dir: "runs/dodrio_56x56_sobel_second_random20/validation_videos"
+log_dir: "runs/dodrio_56x56_sobel_second_random20/logs"
+evaluation_video_file: "runs/dodrio_56x56_sobel_second_random20/evaluation.mp4"
+checkpoint_every: 500
+eval_every: 500
+log_every: 500

--- a/docs/perception_benchmark.md
+++ b/docs/perception_benchmark.md
@@ -57,3 +57,41 @@ first-order gradients. In this run it was both faster and more accurate than
 the first-order variants. The learned 3×3 perception block is trainable and
 valid, but needs a longer or better matched training schedule before it is
 competitive on accuracy.
+
+## Multi-scale experiment
+
+The new `sobel_multiscale` mode combines centered 3×3 and 5×5 Sobel-like
+filters in one convolution:
+
+$$
+P_{\mathrm{multi}}(u) =
+\left[u,
+u_x^{(3)}, u_y^{(3)},
+u_x^{(5)}, u_y^{(5)}\right].
+$$
+
+The 5×5 derivative filters are constructed separably from
+
+$$
+s = [1,4,6,4,1], \qquad d = [-1,-2,0,2,1],
+$$
+
+with
+
+$$
+K_x^{(5)} = s^\mathsf{T}d,
+\qquad
+K_y^{(5)} = \left(K_x^{(5)}\right)^\mathsf{T}.
+$$
+The 3×3 filters are zero-padded into the center of the 5×5 kernel before the
+fused convolution.
+
+A 20-step CPU smoke benchmark at 32×32 produced:
+
+| Method | Step time | Final MSE |
+| --- | ---: | ---: |
+| `sobel_second` | 137.82 ms | 0.1799 |
+| `sobel_multiscale` | 162.01 ms | 0.1689 |
+
+This is only a smoke benchmark and is not directly comparable to the CUDA
+results above; a full CUDA run should be repeated when the GPU is available.

--- a/docs/perception_benchmark.md
+++ b/docs/perception_benchmark.md
@@ -17,10 +17,43 @@ includes XLA compilation; steady-state timing excludes it.
 | `sobel_second` | 13.76 s | 8.73 ms | 0.0873381 |
 | `learned` | 15.21 s | 13.17 ms | 0.1830653 |
 
+For a state channel (u(x,y)), the first- and second-order derivatives are
+
+$$
+u_x = \frac{\partial u}{\partial x}, \qquad
+u_y = \frac{\partial u}{\partial y}, \qquad
+u_{xx} = \frac{\partial^2 u}{\partial x^2}, \qquad
+u_{yy} = \frac{\partial^2 u}{\partial y^2}.
+$$
+
+The second-derivative kernels used by `sobel_second` are
+
+$$
+K_{xx} =
+\begin{bmatrix}
+0 & 0 & 0 \\
+1 & -2 & 1 \\
+0 & 0 & 0
+\end{bmatrix},
+\qquad
+K_{yy} =
+\begin{bmatrix}
+0 & 1 & 0 \\
+0 & -2 & 0 \\
+0 & 1 & 0
+\end{bmatrix}.
+$$
+
+The resulting perception vector is
+
+$$
+P(u) = \left[u,\; u_x,\; u_y,\; u_{xx},\; u_{yy}\right].
+$$
+
+For (C=16) state channels, this produces (5C=80) perception channels.
 `sobel_fused` computes the same X and Y Sobel features in one convolution.
-`sobel_second` adds (u_{xx}) and (u_{yy}) to the perception vector using
-3×3 finite-difference kernels, giving the update network curvature information
-as well as first-order gradients. In this run it was both faster and more
-accurate than the first-order variants. The learned 3×3 perception block is
-trainable and valid, but needs a longer or better matched training schedule
-before it is competitive on accuracy.
+`sobel_second` gives the update network curvature information as well as
+first-order gradients. In this run it was both faster and more accurate than
+the first-order variants. The learned 3×3 perception block is trainable and
+valid, but needs a longer or better matched training schedule before it is
+competitive on accuracy.

--- a/docs/perception_benchmark.md
+++ b/docs/perception_benchmark.md
@@ -17,7 +17,7 @@ includes XLA compilation; steady-state timing excludes it.
 | `sobel_second` | 13.76 s | 8.73 ms | 0.0873381 |
 | `learned` | 15.21 s | 13.17 ms | 0.1830653 |
 
-For a state channel (u(x,y)), the first- and second-order derivatives are
+For a state channel \(u(x,y)\), the first- and second-order derivatives are
 
 $$
 u_x = \frac{\partial u}{\partial x}, \qquad
@@ -50,7 +50,7 @@ $$
 P(u) = \left[u,\; u_x,\; u_y,\; u_{xx},\; u_{yy}\right].
 $$
 
-For (C=16) state channels, this produces (5C=80) perception channels.
+For \(C=16\) state channels, this produces \(5C=80\) perception channels.
 `sobel_fused` computes the same X and Y Sobel features in one convolution.
 `sobel_second` gives the update network curvature information as well as
 first-order gradients. In this run it was both faster and more accurate than

--- a/docs/perception_benchmark.md
+++ b/docs/perception_benchmark.md
@@ -1,0 +1,26 @@
+# Perception experiment
+
+Benchmark command:
+
+```bash
+python scripts/benchmark_perception.py --steps 100 --nca-steps 32
+```
+
+Environment: JAX 0.6.2 on `cuda:0`, 56×56 grid, batch size 8, 100 training
+steps, and 32 NCA steps per training/evaluation pass. The first-call timing
+includes XLA compilation; steady-state timing excludes it.
+
+| Method | Compile + first step | Steady-state step | Final MSE |
+| --- | ---: | ---: | ---: |
+| `sobel` | 14.94 s | 15.08 ms | 0.1371600 |
+| `sobel_fused` | 13.91 s | 14.11 ms | 0.1371776 |
+| `sobel_second` | 13.76 s | 8.73 ms | 0.0873381 |
+| `learned` | 15.21 s | 13.17 ms | 0.1830653 |
+
+`sobel_fused` computes the same X and Y Sobel features in one convolution.
+`sobel_second` adds (u_{xx}) and (u_{yy}) to the perception vector using
+3×3 finite-difference kernels, giving the update network curvature information
+as well as first-order gradients. In this run it was both faster and more
+accurate than the first-order variants. The learned 3×3 perception block is
+trainable and valid, but needs a longer or better matched training schedule
+before it is competitive on accuracy.

--- a/docs/perception_benchmark.md
+++ b/docs/perception_benchmark.md
@@ -86,12 +86,15 @@ $$
 The 3×3 filters are zero-padded into the center of the 5×5 kernel before the
 fused convolution.
 
-A 20-step CPU smoke benchmark at 32×32 produced:
+A full CUDA benchmark at 56×56, batch size 8, 100 training steps, and 32 NCA
+steps per pass produced:
 
 | Method | Step time | Final MSE |
 | --- | ---: | ---: |
-| `sobel_second` | 137.82 ms | 0.1799 |
-| `sobel_multiscale` | 162.01 ms | 0.1689 |
+| `sobel_fused` | 9.87 ms | 0.1372 |
+| `sobel_second` | 8.25 ms | 0.0838 |
+| `sobel_multiscale` | 9.52 ms | 0.1171 |
+| `learned` | 9.78 ms | 0.1831 |
 
-This is only a smoke benchmark and is not directly comparable to the CUDA
-results above; a full CUDA run should be repeated when the GPU is available.
+The multi-scale mode improves accuracy over first-order Sobel, but remains
+slower and less accurate than the second-derivative mode in this run.

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import tensorflow as tf  # type: ignore
 from absl import app, flags  # type: ignore
 
 from nca.trainer import train_and_evaluate, evaluate
@@ -23,8 +22,6 @@ flags.mark_flag_as_required("config_path")
 
 def main(argv):
     del argv
-
-    tf.config.experimental.set_visible_devices([], "GPU")
 
     config = load_config(FLAGS.config_path)
 

--- a/nca/config.py
+++ b/nca/config.py
@@ -10,6 +10,10 @@ class NCAConfig:
     # same features with one convolution, ``sobel_second`` adds second
     # derivatives, while ``learned`` trains a 3x3 perception convolution.
     perception_method: str = "sobel"
+    # Fraction of grid cells initialized as living cells. Zero preserves the
+    # original single-cell center seed.
+    seed_density: float = 0.0
+    seed_random_seed: int = 0
     batch_size: int = 16
     total_training_steps: int = 100000
     eval_every: int = 500

--- a/nca/config.py
+++ b/nca/config.py
@@ -6,6 +6,10 @@ import yaml  # type: ignore
 class NCAConfig:
     dimensions: tuple = (56, 56)
     model_output_len: int = 16
+    # ``sobel`` is the original implementation. ``sobel_fused`` computes the
+    # same features with one convolution, ``sobel_second`` adds second
+    # derivatives, while ``learned`` trains a 3x3 perception convolution.
+    perception_method: str = "sobel"
     batch_size: int = 16
     total_training_steps: int = 100000
     eval_every: int = 500

--- a/nca/config.py
+++ b/nca/config.py
@@ -21,6 +21,9 @@ class NCAConfig:
     log_every: int = 500
     num_nca_steps: int = 64  # number of steps to run NCA for
     n_damage: int = 3  # number of states in a batch to damage
+    # Kept for compatibility with older YAML files.  New configurations
+    # should use ``n_damage`` to control damage augmentation.
+    damage: bool = False
 
     # evaluation parameters
     total_eval_steps: int = 300

--- a/nca/dataset.py
+++ b/nca/dataset.py
@@ -4,7 +4,6 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 import cv2  # type: ignore
-import tensorflow as tf  # type: ignore
 
 from nca.utils import NCHW_to_NHWC, NHWC_to_NCHW
 

--- a/nca/dataset.py
+++ b/nca/dataset.py
@@ -5,7 +5,6 @@ import jax
 import jax.numpy as jnp
 import cv2  # type: ignore
 import tensorflow as tf  # type: ignore
-import keras_cv
 
 from nca.utils import NCHW_to_NHWC, NHWC_to_NCHW
 
@@ -86,28 +85,29 @@ class NCADataGenerator:
         width_factor: float = 0.1,
         seed: int = 10,
     ):
-        img_nhwc = NCHW_to_NHWC(img_nchw)
-        img_nhwc = keras_cv.layers.RandomCutout(height_factor, width_factor, seed=seed)(
-            img_nhwc
-        )
-
-        img_nchw = NHWC_to_NCHW(img_nhwc)
-
-        return img_nchw
+        # Keep augmentation in NumPy.  The previous KerasCV implementation
+        # unconditionally used TensorFlow device kernels, which fails on
+        # machines whose installed CUDA PTX does not match the GPU.
+        img = np.asarray(NCHW_to_NHWC(img_nchw)).copy()
+        rng = np.random.default_rng(seed)
+        n, h, w, _ = img.shape
+        cutout_h = max(1, int(round(h * height_factor)))
+        cutout_w = max(1, int(round(w * width_factor)))
+        for i in range(n):
+            y = rng.integers(0, max(1, h - cutout_h + 1))
+            x = rng.integers(0, max(1, w - cutout_w + 1))
+            img[i, y : y + cutout_h, x : x + cutout_w, :] = 0
+        return NHWC_to_NCHW(img)
 
     @staticmethod
     def random_cutout_circle(img_nchw: Array, seed: int):
-        img_nhwc = NCHW_to_NHWC(img_nchw)
-
-        n, h, w, _ = img_nhwc.shape
-
-        x = tf.linspace(-1.0, 1.0, w)[None, None, :]
-        y = tf.linspace(-1.0, 1.0, h)[None, :, None]
-        center = tf.random.uniform([2, n, 1, 1], -0.5, 0.5, seed=seed)
-        r = tf.random.uniform([n, 1, 1], 0.05, 0.2, seed=seed)
-        x, y = (x - center[0]) / r, (y - center[1]) / r
-        mask: tf.Tensor = tf.cast(x * x + y * y < 1.0, tf.float32)
-        img_masked = img_nhwc * (1.0 - mask[..., tf.newaxis])
-        img_masked = np.asarray(img_masked)
-        img_masked_nchw = NHWC_to_NCHW(img_masked)
-        return img_masked_nchw
+        img = np.asarray(NCHW_to_NHWC(img_nchw)).copy()
+        n, h, w, _ = img.shape
+        rng = np.random.default_rng(seed)
+        yy, xx = np.mgrid[-1 : 1 : complex(0, h), -1 : 1 : complex(0, w)]
+        for i in range(n):
+            cx, cy = rng.uniform(-0.5, 0.5, size=2)
+            radius = rng.uniform(0.05, 0.2)
+            mask = ((xx - cx) / radius) ** 2 + ((yy - cy) / radius) ** 2 < 1.0
+            img[i][mask] = 0
+        return NHWC_to_NCHW(img)

--- a/nca/dataset.py
+++ b/nca/dataset.py
@@ -16,16 +16,30 @@ class NCADataGenerator:
     batch_size: int
     dimensions: Tuple[Any, ...]
     model_output_len: int
+    seed_density: float = 0.0
+    seed_random_seed: int = 0
     seed_state: np.ndarray = field(init=False)
     pool: np.ndarray = field(init=False)
 
     def __post_init__(self):
+        if not 0.0 <= self.seed_density <= 1.0:
+            raise ValueError("seed_density must be between 0.0 and 1.0")
         self.seed_state = np.zeros(
             (self.model_output_len, self.dimensions[0], self.dimensions[1])
         )
 
-        # set chemical channels 1, at the center of the grid
-        self.seed_state[3:, self.dimensions[0] // 2, self.dimensions[1] // 2] = 1.0
+        if self.seed_density == 0.0:
+            # Original single-cell center seed.
+            self.seed_state[
+                3:, self.dimensions[0] // 2, self.dimensions[1] // 2
+            ] = 1.0
+        else:
+            rng = np.random.default_rng(self.seed_random_seed)
+            alive = rng.random(self.dimensions) < self.seed_density
+            # Keep the seed usable even for very small grids/densities.
+            if not np.any(alive):
+                alive[self.dimensions[0] // 2, self.dimensions[1] // 2] = True
+            self.seed_state[3:, alive] = 1.0
 
         self.pool = np.asarray([self.seed_state] * self.pool_size)
 

--- a/nca/model.py
+++ b/nca/model.py
@@ -5,10 +5,18 @@ from typing import Callable
 
 class UpdateModel(nn.Module):
     model_output_len: int = 16
+    perception_method: str = "sobel"
     kernel_init: Callable = nn.initializers.glorot_uniform
 
     def setup(self):
         """Initialize the model layers."""
+        if self.perception_method == "learned":
+            self.perception = nn.Conv(
+                3 * self.model_output_len,
+                kernel_size=(3, 3),
+                padding="SAME",
+                kernel_init=self.kernel_init(),
+            )
         self.conv_1 = nn.Conv(
             128,
             kernel_size=(1, 1),
@@ -31,6 +39,9 @@ class UpdateModel(nn.Module):
         Returns:
             A 2D tensor representing the output data with shape (batch_size, output_len).
         """
+
+        if self.perception_method == "learned":
+            perception_vector = self.perception(perception_vector)
 
         x = self.conv_1(perception_vector)
         x = nn.relu(x)

--- a/nca/nca.py
+++ b/nca/nca.py
@@ -61,6 +61,28 @@ def create_second_derivative_kernels(
     return kernel_xx, kernel_yy
 
 
+def create_multiscale_perception_kernels(
+    input_size: int = 16, output_size: int = 16, use_oihw_layout: bool = True
+) -> tuple:
+    """Create 3x3 and 5x5 Sobel-like first-derivative kernels."""
+    smooth = jnp.array([1, 4, 6, 4, 1], dtype=jnp.float32)
+    derivative = jnp.array([-1, -2, 0, 2, 1], dtype=jnp.float32)
+    kernel_x = smooth[:, None] * derivative[None, :]
+    kernel_y = kernel_x.T
+    kernel_x = kernel_x[:, :, None, None] * jnp.ones(
+        (1, 1, input_size, output_size), dtype=jnp.float32
+    )
+    kernel_y = kernel_y[:, :, None, None] * jnp.ones(
+        (1, 1, input_size, output_size), dtype=jnp.float32
+    )
+
+    if use_oihw_layout:
+        kernel_x = jnp.transpose(kernel_x, (3, 2, 0, 1))
+        kernel_y = jnp.transpose(kernel_y, (3, 2, 0, 1))
+
+    return kernel_x / 32.0, kernel_y / 32.0
+
+
 def perceive(
     state_grid: jnp.ndarray,
     kernel_x: jnp.ndarray,
@@ -68,6 +90,8 @@ def perceive(
     method: str = "sobel",
     kernel_xx: Optional[jnp.ndarray] = None,
     kernel_yy: Optional[jnp.ndarray] = None,
+    kernel_x5: Optional[jnp.ndarray] = None,
+    kernel_y5: Optional[jnp.ndarray] = None,
 ) -> jnp.ndarray:
     """Perceive an input state grid using edge detection.
 
@@ -112,6 +136,28 @@ def perceive(
         return jnp.concatenate(
             [state_grid, grad_x, grad_y, grad_xx, grad_yy], axis=1
         )
+    elif method == "sobel_multiscale":
+        if kernel_x5 is None or kernel_y5 is None:
+            raise ValueError("sobel_multiscale requires 5x5 derivative kernels")
+        # Embed the 3x3 filters in the center of a 5x5 kernel so both scales
+        # can share one convolution call.
+        kernel_x3 = jnp.pad(kernel_x, ((0, 0), (0, 0), (1, 1), (1, 1)))
+        kernel_y3 = jnp.pad(kernel_y, ((0, 0), (0, 0), (1, 1), (1, 1)))
+        fused_kernel = jnp.concatenate(
+            [kernel_x3, kernel_y3, kernel_x5, kernel_y5], axis=0
+        )
+        derivatives = jax.lax.conv(state_grid, fused_kernel, (1, 1), "SAME")
+        channels = state_grid.shape[1]
+        return jnp.concatenate(
+            [
+                state_grid,
+                derivatives[:, :channels],
+                derivatives[:, channels : 2 * channels],
+                derivatives[:, 2 * channels : 3 * channels],
+                derivatives[:, 3 * channels :],
+            ],
+            axis=1,
+        )
     else:
         raise ValueError(f"Unsupported fixed perception method: {method}")
 
@@ -132,6 +178,8 @@ def cell_update(
     perception_method: str = "sobel",
     kernel_xx: Optional[jax.Array] = None,
     kernel_yy: Optional[jax.Array] = None,
+    kernel_x5: Optional[jax.Array] = None,
+    kernel_y5: Optional[jax.Array] = None,
 ) -> jnp.ndarray:
     """
     Cell update function to perform the update on the given state grid.
@@ -164,6 +212,8 @@ def cell_update(
             method=perception_method,
             kernel_xx=kernel_xx,
             kernel_yy=kernel_yy,
+            kernel_x5=kernel_x5,
+            kernel_y5=kernel_y5,
         )
         model_input = jnp.transpose(perceived_grid, (0, 2, 3, 1))
 

--- a/nca/nca.py
+++ b/nca/nca.py
@@ -44,8 +44,30 @@ def create_perception_kernel(
     return kernel_x / 8.0, kernel_y / 8.0
 
 
+def create_second_derivative_kernels(
+    input_size: int = 16, output_size: int = 16, use_oihw_layout: bool = True
+) -> tuple:
+    """Create finite-difference kernels for the pure second derivatives."""
+    kernel_xx = jnp.zeros((3, 3, input_size, output_size), dtype=jnp.float32)
+    kernel_xx = kernel_xx + jnp.array([[0, 0, 0], [1, -2, 1], [0, 0, 0]])[
+        :, :, jnp.newaxis, jnp.newaxis
+    ]
+    kernel_yy = kernel_xx.transpose(1, 0, 2, 3)
+
+    if use_oihw_layout:
+        kernel_xx = jnp.transpose(kernel_xx, (3, 2, 0, 1))
+        kernel_yy = jnp.transpose(kernel_yy, (3, 2, 0, 1))
+
+    return kernel_xx, kernel_yy
+
+
 def perceive(
-    state_grid: jnp.ndarray, kernel_x: jnp.ndarray, kernel_y: jnp.ndarray
+    state_grid: jnp.ndarray,
+    kernel_x: jnp.ndarray,
+    kernel_y: jnp.ndarray,
+    method: str = "sobel",
+    kernel_xx: Optional[jnp.ndarray] = None,
+    kernel_yy: Optional[jnp.ndarray] = None,
 ) -> jnp.ndarray:
     """Perceive an input state grid using edge detection.
 
@@ -64,9 +86,34 @@ def perceive(
         input state grid, and the next two sets correspond to the
         gradients in the x and y directions, respectively.
     """
-    # Compute gradients using convolution with Sobel operators
-    grad_x = jax.lax.conv(state_grid, kernel_x, (1, 1), "SAME")  # -> NCHW
-    grad_y = jax.lax.conv(state_grid, kernel_y, (1, 1), "SAME")  # -> NCHW
+    if method == "sobel":
+        # Original implementation: two separate convolutions.
+        grad_x = jax.lax.conv(state_grid, kernel_x, (1, 1), "SAME")
+        grad_y = jax.lax.conv(state_grid, kernel_y, (1, 1), "SAME")
+    elif method == "sobel_fused":
+        # Concatenating output channels lets XLA use one convolution while
+        # preserving the exact feature ordering of the original path.
+        fused_kernel = jnp.concatenate([kernel_x, kernel_y], axis=0)
+        gradients = jax.lax.conv(state_grid, fused_kernel, (1, 1), "SAME")
+        channels = state_grid.shape[1]
+        grad_x, grad_y = gradients[:, :channels], gradients[:, channels:]
+    elif method == "sobel_second":
+        if kernel_xx is None or kernel_yy is None:
+            raise ValueError("sobel_second requires second-derivative kernels")
+        fused_kernel = jnp.concatenate(
+            [kernel_x, kernel_y, kernel_xx, kernel_yy], axis=0
+        )
+        derivatives = jax.lax.conv(state_grid, fused_kernel, (1, 1), "SAME")
+        channels = state_grid.shape[1]
+        grad_x = derivatives[:, :channels]
+        grad_y = derivatives[:, channels : 2 * channels]
+        grad_xx = derivatives[:, 2 * channels : 3 * channels]
+        grad_yy = derivatives[:, 3 * channels :]
+        return jnp.concatenate(
+            [state_grid, grad_x, grad_y, grad_xx, grad_yy], axis=1
+        )
+    else:
+        raise ValueError(f"Unsupported fixed perception method: {method}")
 
     # Concatenate the state grid with the gradients along the channel axis
     perceived_grid = jnp.concatenate([state_grid, grad_x, grad_y], axis=1)
@@ -82,6 +129,9 @@ def cell_update(
     kernel_x: jax.Array,
     kernel_y: jax.Array,
     update_prob: float = 0.5,
+    perception_method: str = "sobel",
+    kernel_xx: Optional[jax.Array] = None,
+    kernel_yy: Optional[jax.Array] = None,
 ) -> jnp.ndarray:
     """
     Cell update function to perform the update on the given state grid.
@@ -102,12 +152,22 @@ def cell_update(
     """
     pre_alive_mask = alive_masking(state_grid[:, 3, :, :])
 
-    perceived_grid = perceive(state_grid, kernel_x, kernel_y)
+    # Fixed perception operates on NCHW. Learned perception is a trainable
+    # model layer and receives the raw state in NHWC.
+    if perception_method == "learned":
+        model_input = jnp.transpose(state_grid, (0, 2, 3, 1))
+    else:
+        perceived_grid = perceive(
+            state_grid,
+            kernel_x,
+            kernel_y,
+            method=perception_method,
+            kernel_xx=kernel_xx,
+            kernel_yy=kernel_yy,
+        )
+        model_input = jnp.transpose(perceived_grid, (0, 2, 3, 1))
 
-    # Transpose: NCHW -> NHWC
-    perceived_grid = jnp.transpose(perceived_grid, (0, 2, 3, 1))
-
-    ds = model_fn.apply(params, perceived_grid)
+    ds = model_fn.apply(params, model_input)
 
     # Stochastic update
     rand_mask = jax.random.uniform(key, shape=ds.shape[:-1]) < update_prob

--- a/nca/trainer.py
+++ b/nca/trainer.py
@@ -47,7 +47,9 @@ def create_state(config: NCAConfig) -> Tuple[train_state.TrainState, Any]:
 
     restored_dict = None
     if config.weights_dir:
-        restored_dict = checkpoints.restore_checkpoint(config.weights_dir, target=None)
+        restored_dict = checkpoints.restore_checkpoint(
+            os.path.abspath(config.weights_dir), target=None
+        )
 
     if restored_dict == None:
         params = model.init(jax.random.PRNGKey(0), dummy_data)
@@ -64,7 +66,9 @@ def create_state(config: NCAConfig) -> Tuple[train_state.TrainState, Any]:
     )
 
     if config.checkpoint_dir:
-        state = checkpoints.restore_checkpoint(config.checkpoint_dir, target=state)
+        state = checkpoints.restore_checkpoint(
+            os.path.abspath(config.checkpoint_dir), target=state
+        )
 
     # Return the TrainState object and the learning rate schedule
     return state, learning_rate_schedule
@@ -354,7 +358,7 @@ def train_and_evaluate(config: NCAConfig):
         if step % config.checkpoint_every == 0 and config.checkpoint_dir:
             # save checkpoint
             checkpoints.save_checkpoint(
-                config.checkpoint_dir, state, step=state.step, keep=3
+                os.path.abspath(config.checkpoint_dir), state, step=state.step, keep=3
             )
 
         # split the key for the next step
@@ -374,7 +378,7 @@ def evaluate(config: NCAConfig, output_video_path: Optional[str] = None) -> None
     state, _ = create_state(config)
 
     if config.weights_dir:
-        state = checkpoints.restore_checkpoint(config.weights_dir, state)
+        state = checkpoints.restore_checkpoint(os.path.abspath(config.weights_dir), state)
 
     cell_update_fn = create_cell_update_fn(config, state.apply_fn)
 

--- a/nca/trainer.py
+++ b/nca/trainer.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 import cv2  # type: ignore
 import numpy as np
 from typing import Tuple, List, Dict, Any, Callable, Optional
-import tensorflow as tf  # type: ignore
 from tqdm import tqdm  # type: ignore
 import os
 from tensorboardX import SummaryWriter  # type: ignore
@@ -435,10 +434,10 @@ def evaluate(config: NCAConfig, output_video_path: Optional[str] = None) -> None
     # NCHW -> NHWC
     rgb = jnp.transpose(rgb, (0, 2, 3, 1))
 
-    # resize with tf
-    rgb = tf.image.resize(
-        rgb, (256, 256), method=tf.image.ResizeMethod.NEAREST_NEIGHBOR
-    ).numpy()
+    # Resize through JAX so evaluation does not initialize a second GPU
+    # runtime (TensorFlow and JAX competing for the same CUDA context).
+    rgb = jax.image.resize(rgb, (rgb.shape[0], 256, 256, 3), method="nearest")
+    rgb = np.asarray(rgb)
 
     if output_video_path is None:
         make_video(rgb, config.evaluation_video_file)

--- a/nca/trainer.py
+++ b/nca/trainer.py
@@ -46,6 +46,7 @@ def create_state(config: NCAConfig) -> Tuple[train_state.TrainState, Any]:
         (1, config.dimensions[0], config.dimensions[1], config.model_output_len * 3),
     )
 
+    restored_dict = None
     if config.weights_dir:
         restored_dict = checkpoints.restore_checkpoint(config.weights_dir, target=None)
 
@@ -167,7 +168,7 @@ def train_step(
     (loss, state_grid_sequence), grad = grad_fn(state.params, state_grid, key)
 
     if apply_grad:
-        grad = jax.tree_map(
+        grad = jax.tree_util.tree_map(
             lambda g: jnp.nan_to_num(g / (jnp.linalg.norm(g) + 1e-8)), grad
         )
         state = state.apply_gradients(grads=grad)

--- a/nca/trainer.py
+++ b/nca/trainer.py
@@ -283,6 +283,8 @@ def train_and_evaluate(config: NCAConfig):
         batch_size=config.batch_size,
         dimensions=config.dimensions,
         model_output_len=config.model_output_len,
+        seed_density=config.seed_density,
+        seed_random_seed=config.seed_random_seed,
     )
 
     train_target = dataset_generator.get_target(config.target_filename)
@@ -439,6 +441,8 @@ def evaluate(config: NCAConfig, output_video_path: Optional[str] = None) -> None
         batch_size=config.batch_size,
         dimensions=config.dimensions,
         model_output_len=config.model_output_len,
+        seed_density=config.seed_density,
+        seed_random_seed=config.seed_random_seed,
     )
 
     nca_looper_fn = partial(

--- a/nca/trainer.py
+++ b/nca/trainer.py
@@ -19,6 +19,7 @@ from nca.model import UpdateModel
 from nca.nca import (
     create_perception_kernel,
     create_second_derivative_kernels,
+    create_multiscale_perception_kernels,
     cell_update,
 )
 from nca.config import NCAConfig
@@ -43,7 +44,13 @@ def create_state(config: NCAConfig) -> Tuple[train_state.TrainState, Any]:
     )
 
     # Initialize the model with random weights
-    valid_methods = {"sobel", "sobel_fused", "sobel_second", "learned"}
+    valid_methods = {
+        "sobel",
+        "sobel_fused",
+        "sobel_second",
+        "sobel_multiscale",
+        "learned",
+    }
     if config.perception_method not in valid_methods:
         raise ValueError(
             f"perception_method must be one of {sorted(valid_methods)}, "
@@ -62,7 +69,12 @@ def create_state(config: NCAConfig) -> Tuple[train_state.TrainState, Any]:
             config.model_output_len
             if config.perception_method == "learned"
             else config.model_output_len
-            * (5 if config.perception_method == "sobel_second" else 3),
+            * (
+                5
+                if config.perception_method
+                in {"sobel_second", "sobel_multiscale"}
+                else 3
+            ),
         ),
     )
 
@@ -113,6 +125,13 @@ def create_cell_update_fn(
             output_size=config.model_output_len,
             use_oihw_layout=True,
         )
+    kernel_x5 = kernel_y5 = None
+    if config.perception_method == "sobel_multiscale":
+        kernel_x5, kernel_y5 = create_multiscale_perception_kernels(
+            input_size=config.model_output_len,
+            output_size=config.model_output_len,
+            use_oihw_layout=True,
+        )
 
     # define a function to update the cell state grid using the provided model function and parameters
     def cell_update_fn(key, state_grid, params):
@@ -128,6 +147,8 @@ def create_cell_update_fn(
             perception_method=config.perception_method,
             kernel_xx=kernel_xx,
             kernel_yy=kernel_yy,
+            kernel_x5=kernel_x5,
+            kernel_y5=kernel_y5,
         )
 
     # if we want to use jit, then jit the cell_update_fn function

--- a/nca/trainer.py
+++ b/nca/trainer.py
@@ -16,7 +16,11 @@ from tensorboardX import SummaryWriter  # type: ignore
 from functools import partial
 
 from nca.model import UpdateModel
-from nca.nca import create_perception_kernel, cell_update
+from nca.nca import (
+    create_perception_kernel,
+    create_second_derivative_kernels,
+    cell_update,
+)
 from nca.config import NCAConfig
 from nca.dataset import NCADataGenerator
 from nca.utils import make_video, NCHW_to_NHWC, mse
@@ -39,10 +43,27 @@ def create_state(config: NCAConfig) -> Tuple[train_state.TrainState, Any]:
     )
 
     # Initialize the model with random weights
-    model = UpdateModel(model_output_len=config.model_output_len)
+    valid_methods = {"sobel", "sobel_fused", "sobel_second", "learned"}
+    if config.perception_method not in valid_methods:
+        raise ValueError(
+            f"perception_method must be one of {sorted(valid_methods)}, "
+            f"got {config.perception_method!r}"
+        )
+    model = UpdateModel(
+        model_output_len=config.model_output_len,
+        perception_method=config.perception_method,
+    )
     dummy_data = jax.random.normal(
         jax.random.PRNGKey(0),
-        (1, config.dimensions[0], config.dimensions[1], config.model_output_len * 3),
+        (
+            1,
+            config.dimensions[0],
+            config.dimensions[1],
+            config.model_output_len
+            if config.perception_method == "learned"
+            else config.model_output_len
+            * (5 if config.perception_method == "sobel_second" else 3),
+        ),
     )
 
     restored_dict = None
@@ -85,6 +106,13 @@ def create_cell_update_fn(
         output_size=config.model_output_len,
         use_oihw_layout=True,
     )
+    kernel_xx = kernel_yy = None
+    if config.perception_method == "sobel_second":
+        kernel_xx, kernel_yy = create_second_derivative_kernels(
+            input_size=config.model_output_len,
+            output_size=config.model_output_len,
+            use_oihw_layout=True,
+        )
 
     # define a function to update the cell state grid using the provided model function and parameters
     def cell_update_fn(key, state_grid, params):
@@ -97,6 +125,9 @@ def create_cell_update_fn(
             kernel_x=kernel_x,
             kernel_y=kernel_y,
             update_prob=config.stochastic_update_prob,
+            perception_method=config.perception_method,
+            kernel_xx=kernel_xx,
+            kernel_yy=kernel_yy,
         )
 
     # if we want to use jit, then jit the cell_update_fn function

--- a/nca/utils.py
+++ b/nca/utils.py
@@ -2,7 +2,13 @@ import jax
 import jax.numpy as jnp
 import tensorflow as tf
 import numpy as np
-from moviepy.editor import ImageSequenceClip  # type: ignore
+
+try:
+    # MoviePy 1.x exposed this from ``moviepy.editor``; MoviePy 2.x exports
+    # it from the package root.
+    from moviepy import ImageSequenceClip  # type: ignore
+except ImportError:  # pragma: no cover - exercised with MoviePy 1.x
+    from moviepy.editor import ImageSequenceClip  # type: ignore
 import tempfile
 from glob import glob
 import cv2  # type: ignore

--- a/nca/utils.py
+++ b/nca/utils.py
@@ -1,6 +1,5 @@
 import jax
 import jax.numpy as jnp
-import tensorflow as tf
 import numpy as np
 
 try:
@@ -16,7 +15,6 @@ import os
 
 from typing import List, Any, Union
 
-
 Array = Union[np.ndarray, jnp.ndarray]
 
 
@@ -31,10 +29,6 @@ def NCHW_to_NHWC(x: Array) -> Array:
     """
     if isinstance(x, np.ndarray):
         return np.transpose(x, (0, 2, 3, 1))
-    elif isinstance(x, tf.Tensor):
-        x_dl = tf.experimental.dlpack.to_dlpack(x)
-        x = jax.dlpack.from_dlpack(x_dl)
-
     return jnp.transpose(x, (0, 2, 3, 1))
 
 
@@ -49,10 +43,6 @@ def NHWC_to_NCHW(x: Array) -> Array:
     """
     if isinstance(x, np.ndarray):
         return np.transpose(x, (0, 3, 1, 2))
-    elif isinstance(x, tf.Tensor):
-        x_dl = tf.experimental.dlpack.to_dlpack(x)
-        x = jax.dlpack.from_dlpack(x_dl)
-
     return jnp.transpose(x, (0, 3, 1, 2))
 
 

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+
+# NVIDIA CUDA 12 JAX plugin.  The NVIDIA driver supplies CUDA compatibility;
+# the CUDA libraries are installed into the Python environment by this extra.
+jax[cuda12]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,9 @@
 flax
 optax
-jax[cpu]
+jax
 black
 moviepy
 tensorboardX
 pytest
 opencv-python
-imageio==2.27
-tensorflow
-keras_cv
+imageio>=2.29,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flax
 optax
+jax[cpu]
 black
 moviepy
 tensorboardX

--- a/scripts/benchmark_perception.py
+++ b/scripts/benchmark_perception.py
@@ -99,7 +99,13 @@ def main():
     parser.add_argument(
         "--methods",
         nargs="+",
-        default=["sobel", "sobel_fused", "sobel_second", "learned"],
+        default=[
+            "sobel",
+            "sobel_fused",
+            "sobel_second",
+            "sobel_multiscale",
+            "learned",
+        ],
     )
     args = parser.parse_args()
 

--- a/scripts/benchmark_perception.py
+++ b/scripts/benchmark_perception.py
@@ -1,0 +1,117 @@
+"""Compare NCA perception implementations on the same short training run.
+
+Example:
+    python scripts/benchmark_perception.py --steps 100 --nca-steps 32
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+import time
+
+import jax
+import jax.numpy as jnp
+
+# Allow this file to be run directly from the repository root.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from nca.config import NCAConfig
+from nca.dataset import NCADataGenerator
+from nca.trainer import create_cell_update_fn, create_state, evaluate_step, train_step
+
+
+def benchmark(method: str, steps: int, nca_steps: int, dimensions: tuple[int, int]):
+    config = NCAConfig(
+        dimensions=dimensions,
+        model_output_len=16,
+        batch_size=8,
+        total_training_steps=steps,
+        num_nca_steps=nca_steps,
+        # Measure accuracy at the same propagation horizon used for training.
+        total_eval_steps=nca_steps,
+        target_filename="emoji_imgs/smile.png",
+        weights_dir="",
+        checkpoint_dir="",
+        perception_method=method,
+    )
+    state, _ = create_state(config)
+    update_fn = create_cell_update_fn(config, state.apply_fn, use_jit=False)
+    train_fn = jax.jit(
+        lambda key, train_state, grid, target: train_step(
+            key, train_state, grid, target, update_fn, num_nca_steps=nca_steps
+        )
+    )
+
+    generator = NCADataGenerator(
+        pool_size=config.batch_size,
+        batch_size=config.batch_size,
+        dimensions=dimensions,
+        model_output_len=config.model_output_len,
+    )
+    target = generator.get_target(config.target_filename)
+    state_grid = jnp.asarray(generator.pool)
+    key = jax.random.PRNGKey(0)
+
+    # The first call includes XLA compilation and is reported separately.
+    start = time.perf_counter()
+    state, loss, _ = train_fn(key, state, state_grid, target)
+    jax.block_until_ready(loss)
+    compile_and_first_step_s = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for _ in range(steps - 1):
+        key, step_key = jax.random.split(key)
+        state, loss, _ = train_fn(step_key, state, state_grid, target)
+        jax.block_until_ready(loss)
+    steady_state_s = time.perf_counter() - start
+
+    _, eval_loss = evaluate_step(
+        state,
+        state_grid[:1],
+        target[:1],
+        update_fn,
+        num_nca_steps=config.total_eval_steps,
+    )
+    jax.block_until_ready(eval_loss)
+
+    return {
+        "method": method,
+        "steps": steps,
+        "nca_steps": nca_steps,
+        "dimensions": list(dimensions),
+        "compile_and_first_step_s": compile_and_first_step_s,
+        "steady_state_total_s": steady_state_s,
+        "steady_state_step_s": steady_state_s / max(steps - 1, 1),
+        "train_loss": float(loss),
+        # evaluate_step already reduces the final propagated RGBA prediction
+        # against the target, avoiding accidental broadcasting over time.
+        "eval_mse": float(eval_loss),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--steps", type=int, default=100)
+    parser.add_argument("--nca-steps", type=int, default=32)
+    parser.add_argument("--height", type=int, default=56)
+    parser.add_argument("--width", type=int, default=56)
+    parser.add_argument(
+        "--methods",
+        nargs="+",
+        default=["sobel", "sobel_fused", "sobel_second", "learned"],
+    )
+    args = parser.parse_args()
+
+    print(
+        json.dumps({"jax": jax.__version__, "devices": [str(d) for d in jax.devices()]})
+    )
+    results = [
+        benchmark(method, args.steps, args.nca_steps, (args.height, args.width))
+        for method in args.methods
+    ]
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -15,6 +15,15 @@ def test_initialization(generator: NCADataGenerator):
     assert generator.pool.shape == (100, 16, 40, 40)
 
 
+def test_random_seed_distribution():
+    generator = NCADataGenerator(
+        2, 1, (40, 40), 16, seed_density=0.2, seed_random_seed=0
+    )
+    alive = generator.seed_state[3] > 0
+    assert 0.15 < alive.mean() < 0.25
+    np.testing.assert_array_equal(alive, generator.seed_state[4] > 0)
+
+
 def test_sample_generation(generator: NCADataGenerator):
     key = jax.random.PRNGKey(0)
 

--- a/tests/test_nca.py
+++ b/tests/test_nca.py
@@ -35,6 +35,20 @@ def test_perception_function():
 
     assert y.shape == (1, 16 * 3, 32, 32)
 
+    fused = perceive(x, kernel_x, kernel_y, method="sobel_fused")
+    np.testing.assert_allclose(y, fused)
+
+    kernel_xx, kernel_yy = create_second_derivative_kernels(16, 16)
+    second = perceive(
+        x,
+        kernel_x,
+        kernel_y,
+        method="sobel_second",
+        kernel_xx=kernel_xx,
+        kernel_yy=kernel_yy,
+    )
+    assert second.shape == (1, 16 * 5, 32, 32)
+
 
 def test_cell_update_function():
     # Set up random input data
@@ -56,3 +70,22 @@ def test_cell_update_function():
     y = cell_update(key, x, model, params, kernel_x, kernel_y, update_prob=0.5)
 
     assert y.shape == (4, 16, 32, 32)
+
+
+def test_learned_perception_cell_update():
+    key = random.PRNGKey(0)
+    x = random.normal(key, (4, 16, 32, 32))
+    model = UpdateModel(perception_method="learned")
+    params = model.init(key, random.normal(key, (1, 32, 32, 16)))
+    kernel_x, kernel_y = create_perception_kernel(16, 16, use_oihw_layout=True)
+    y = cell_update(
+        key,
+        x,
+        model,
+        params,
+        kernel_x,
+        kernel_y,
+        update_prob=0.5,
+        perception_method="learned",
+    )
+    assert y.shape == x.shape

--- a/tests/test_nca.py
+++ b/tests/test_nca.py
@@ -49,6 +49,17 @@ def test_perception_function():
     )
     assert second.shape == (1, 16 * 5, 32, 32)
 
+    kernel_x5, kernel_y5 = create_multiscale_perception_kernels(16, 16)
+    multiscale = perceive(
+        x,
+        kernel_x,
+        kernel_y,
+        method="sobel_multiscale",
+        kernel_x5=kernel_x5,
+        kernel_y5=kernel_y5,
+    )
+    assert multiscale.shape == (1, 16 * 5, 32, 32)
+
 
 def test_cell_update_function():
     # Set up random input data


### PR DESCRIPTION
## Summary

This PR explores faster and richer perception blocks for the NCA update step and adds reproducible timing/accuracy experiments.

## What changed

- Added configurable perception modes: sobel, sobel_fused, sobel_second, sobel_multiscale, and learned.
- Added second-derivative finite-difference kernels.
- Added multi-scale 3x3 + 5x5 Sobel-like first-derivative kernels.
- Added configurable distributed initialization with seed_density and seed_random_seed.
- Added 20% random-seed Dodrio 56x56 training configuration.
- Added tests for fused equivalence, perception channel shapes, and distributed seeds.
- Added scripts/benchmark_perception.py.
- Recorded benchmark equations and results in docs/perception_benchmark.md.

## Mathematical formulation

For a state channel \(u(x,y)\):

$$
u_x = \frac{\partial u}{\partial x}, \qquad
u_y = \frac{\partial u}{\partial y}, \qquad
u_{xx} = \frac{\partial^2 u}{\partial x^2}, \qquad
u_{yy} = \frac{\partial^2 u}{\partial y^2}.
$$

The second-derivative perception vector is:

$$
P_{\mathrm{second}}(u) =
\left[u,\; u_x,\; u_y,\; u_{xx},\; u_{yy}\right].
$$

The multi-scale mode uses:

$$
P_{\mathrm{multi}}(u) =
\left[u,\; u_x^{(3)},\; u_y^{(3)},\; u_x^{(5)},\; u_y^{(5)}\right].
$$

## CUDA benchmark

JAX 0.6.2, cuda:0, 56x56 grid, batch size 8, 100 training steps, 32 NCA steps per pass:

| Method | Steady-state step | Final MSE |
| --- | ---: | ---: |
| sobel_fused | 9.87 ms | 0.1372 |
| sobel_second | 8.25 ms | 0.0838 |
| sobel_multiscale | 9.52 ms | 0.1171 |
| learned | 9.78 ms | 0.1831 |

sobel_second is currently the best measured operator.

## Distributed-seed training experiment

The original seed activates only the center cell. The new configuration samples a fixed random occupancy mask:

$$
M_{ij} \sim \operatorname{Bernoulli}(p), \qquad p=0.20
$$

and initializes the chemical channels as:

$$
x_{cij}^{(0)} =
\begin{cases}
1, & c \ge 3 \land M_{ij}=1, \\
0, & \text{otherwise}.
\end{cases}
$$

The Dodrio experiment uses 56x56 resolution, sobel_second, and seed_density = 0.2. With seed_random_seed = 0, the realized occupancy is 20.85%. Training is running under:

runs/dodrio_56x56_sobel_second_random20/

## Validation

- pytest -q with JAX CPU backend: 17 passed
- git diff --check
- CUDA benchmark completed on cuda:0
- Distributed-seed training launched successfully